### PR TITLE
Store binary artifacts on PR/master

### DIFF
--- a/.github/workflows/add_artifact_urls.yml
+++ b/.github/workflows/add_artifact_urls.yml
@@ -1,0 +1,21 @@
+name: add artifact links to pull request and related issues
+on:
+  workflow_run:
+    workflows: ['Build']
+    types: [completed]
+
+jobs:
+  artifacts-url-comments:
+    name: add artifact links to pull request and related issues job
+    runs-on: windows-2019
+    steps:
+      - name: add artifact links to pull request and related issues step
+        uses: tonyhallett/artifacts-url-comments@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          prefix: Here are the build results
+          suffix: Artifacts will only be retained for 90 days.
+          format: name
+          addTo: pull
+        continue-on-error: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,3 +24,18 @@ jobs:
             ${{ runner.os }}-build-go-${{ hashFiles('**/go.sum') }}
       - name: Build
         run: make build
+      - name: Store operator binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-operator
+          path: build/elemental-operator
+      - name: Store register binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-register
+          path: build/elemental-register
+      - name: Store support binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: elemental-support
+          path: build/elemental-support


### PR DESCRIPTION
Useful to create special binaries and give them to people for quick
testing if we store those built binaries from PRs/main branch

Signed-off-by: Itxaka <igarcia@suse.com>