### PR TITLE
Several improvements to the support command

### DIFF
--- a/cmd/support/main.go
+++ b/cmd/support/main.go
@@ -174,7 +174,7 @@ func run() (err error) {
 			describeK8sResource(crd, tempDir)
 		}
 		// get k8s logs
-		for _, namespace := range []string{"cattle-system", "kube-system", "ingress-nginx", "calico-system"} {
+		for _, namespace := range []string{"cattle-system", "kube-system", "ingress-nginx", "calico-system", "cattle-fleet-system"} {
 			logrus.Infof("Getting k8s logs for namespace %s", namespace)
 			getK8sPodsLogs(namespace, tempDir)
 		}


### PR DESCRIPTION
- Remove : from names as it may not be supported on some systems
 - Fix kubectl finding
 - Fix missing kubeconfig in one command
 - Store also the resources description
 - Add apps, jobs and plans
 - Check kubectl/kubeconfig just once
 - Add missing namespaces
 - Add NetworkManager log

Signed-off-by: Itxaka <igarcia@suse.com>